### PR TITLE
changed static method fromLocale to more generic create

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ use SebastianBergmann\Money\IntlFormatter;
 $m = new Money(100, new Currency('EUR'));
 
 // Format a Money object using PHP's built-in NumberFormatter (German locale)
-$f = IntlFormatter::fromLocale('de_DE');
+$f = IntlFormatter::create('de_DE');
 
 print $f->format($m);
 ```

--- a/src/IntlFormatter.php
+++ b/src/IntlFormatter.php
@@ -29,15 +29,16 @@ class IntlFormatter implements Formatter
     private $numberFormatter;
 
     /**
-     * @param  string $locale
+     * @param string $locale
+     * @param int    $style
      * @return static
      */
-    public static function fromLocale($locale)
+    public static function create($locale, $style = NumberFormatter::CURRENCY)
     {
         return new static(
             new NumberFormatter(
                 $locale,
-                NumberFormatter::CURRENCY
+                $style
             )
         );
     }
@@ -63,4 +64,5 @@ class IntlFormatter implements Formatter
             $money->getCurrency()->getCurrencyCode()
         );
     }
+
 }

--- a/tests/IntlFormatterTest.php
+++ b/tests/IntlFormatterTest.php
@@ -13,7 +13,7 @@ namespace SebastianBergmann\Money;
 class IntlFormatterTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * @covers \SebastianBergmann\Money\IntlFormatter::fromLocale
+     * @covers \SebastianBergmann\Money\IntlFormatter::create
      * @covers \SebastianBergmann\Money\IntlFormatter::__construct
      * @covers \SebastianBergmann\Money\IntlFormatter::format
      * @uses   \SebastianBergmann\Money\Currency
@@ -21,9 +21,37 @@ class IntlFormatterTest extends \PHPUnit_Framework_TestCase
      */
     public function testMoneyObjectCanBeFormattedAsString()
     {
-        $f = IntlFormatter::fromLocale('de_DE');
+        $f = IntlFormatter::create('de_DE');
         $m = new Money(100, new Currency('EUR'));
 
         $this->assertEquals('1,00 €', $f->format($m));
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\IntlFormatter::create
+     * @covers \SebastianBergmann\Money\IntlFormatter::__construct
+     * @covers \SebastianBergmann\Money\IntlFormatter::format
+     * @uses   \SebastianBergmann\Money\Currency
+     * @uses   \SebastianBergmann\Money\Money
+     */
+    public function testStaticDecimalFormatter()
+    {
+        $m = new Money(110, new Currency('EUR'));
+
+        $this->assertEquals('1.1', IntlFormatter::create('en_US', \NumberFormatter::DECIMAL)->format($m));
+    }
+
+    /**
+     * @covers \SebastianBergmann\Money\IntlFormatter::create
+     * @covers \SebastianBergmann\Money\IntlFormatter::__construct
+     * @covers \SebastianBergmann\Money\IntlFormatter::format
+     * @uses   \SebastianBergmann\Money\Currency
+     * @uses   \SebastianBergmann\Money\Money
+     */
+    public function testStaticFormatter()
+    {
+        $m = new Money(110, new Currency('EUR'));
+
+        $this->assertEquals('1,10 €', IntlFormatter::create('de_DE')->format($m));
     }
 }


### PR DESCRIPTION
this allows to define the style of NumberFormatter additional to the locale with the static creation.

i had the case where i had to render a localized decimal from a money object, this would be possible now with a nice one-liner:

    IntlFormatter::create('de_DE', \NumberFormatter::DECIMAL)->format($money);

Because its not only fromLocale now, i renamed it more generic: create.

Constructor Injection is still possible for more advanced cases, but this enables sometimes conveniant "instanciate and forget" usage.  